### PR TITLE
Remove default ice. Add support for optional Ice 3.6 python wheel package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,14 @@
----
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker 'molecule<1.22'
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 sudo: required
 language: python
 
@@ -5,7 +6,7 @@ services:
   - docker
 
 install:
-  - pip install ansible docker 'molecule<1.22'
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role Variables
 Required:
 - `ice_version`: The Ice version, either 3.5 or 3.6
 
-Optional:
+Optional (expert users only):
 - `ice_python_wheel`: URL to a python wheel package to be installed.
   You can use this to provide a precompiled ice-py package for 3.6 as an alternative to automatically compiling from the source package.
 
@@ -19,6 +19,15 @@ Notes
 -----
 Note that 3.6 requires ice-python to be installed using pip, and will result in the installation of several development tools and libraries unless `ice_python_wheel` is provided.
 The pip version is required in major.minor.patch form so `vars/ice-3.6.yml` will need to be updated whenever there is a new patch release.
+
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+        - role: openmicroscopy.ice
+          ice_version: "3.6"
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Role Variables
 Required:
 - `ice_version`: The Ice version, either 3.5 or 3.6
 
+Optional:
+- `ice_python_wheel`: URL to a python wheel package to be installed.
+  You can use this to provide a precompiled ice-py package for 3.6 as an alternative to automatically compiling from the source package.
+
 
 Notes
 -----
-Note that 3.6 requires ice-python to be installed using pip, and will result in the installation of several development tools and libraries.
+Note that 3.6 requires ice-python to be installed using pip, and will result in the installation of several development tools and libraries unless `ice_python_wheel` is provided.
 The pip version is required in major.minor.patch form so `vars/ice-3.6.yml` will need to be updated whenever there is a new patch release.
 
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
 Role Name
 =========
 
-Install Zeroc Ice. Currently supports versions 3.5 (default) and 3.6.
+Install Zeroc Ice.
 
-Note that 3.6 requires ice-python to be installed using pip, and will result in the installation of several development tools and libraries.
-
-TODO: The pip version is required in major.minor.patch form so
-`vars/ice-3.6.yml` will need to be updated whenever there is a new patch
-release.
-
-TODO: Allow installation of a multi-version ice archive.
 
 Role Variables
 --------------
 
-Optional variables:
+Required:
+- `ice_version`: The Ice version, either 3.5 or 3.6
 
-- `ice_version`: The Ice version, either 3.5 (default) or 3.6
 
-Internal variables: See `vars/*.yml`
+Notes
+-----
+Note that 3.6 requires ice-python to be installed using pip, and will result in the installation of several development tools and libraries.
+The pip version is required in major.minor.patch form so `vars/ice-3.6.yml` will need to be updated whenever there is a new patch release.
+
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,0 @@
----
-# defaults file for roles/ice
-
-# Ice version
-ice_version: 3.5

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: ZeroC Ice
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: ome-devel@lists.openmicroscopy.org.uk
-  description: ZeroC Ice
+  description: ZeroC Ice including Python
   company: Open Microscopy Environment
   license: BSD
   min_ansible_version: 2.2
@@ -10,4 +10,6 @@ galaxy_info:
     - 7
   galaxy_tags: []
 
-dependencies: []
+dependencies:
+- name: openmicroscopy.basedeps
+  src: openmicroscopy.basedeps

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+# Default driver
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: ice-35
+    - name: ice-36
+
+docker:
+  containers:
+  - name: ice-35
+    image: centos
+    image_version: 7
+  - name: ice-36
+    image: centos
+    image_version: 7
+
+ansible:
+  host_vars:
+    ice-35:
+      ice_version: "3.5"
+    ice-36:
+      ice_version: "3.6"
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-ice

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,18 +32,9 @@
   with_items: "{{ ice_pip_dependencies }}"
   when: ice_pip_dependencies
 
-- name: zeroc ice | pip install packages (ansible < 2.2)
-  become: yes
-  pip:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ ice_pip_packages }}"
-  when: "ice_pip_packages and {{ ansible_version.full | version_compare('2.2', '<') }}"
-
-# https://github.com/ansible/ansible/issues/19321
-- name: zeroc ice | pip install packages (ansible >= 2.2)
+- name: zeroc ice | pip install packages
   become: yes
   pip:
     name: "{{ ice_pip_packages }}"
     state: present
-  when: "ice_pip_packages and {{ ansible_version.full | version_compare('2.2', '>=') }}"
+  when: "ice_pip_packages"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,11 +30,25 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ ice_pip_dependencies }}"
-  when: ice_pip_dependencies
+  when: "ice_pip_dependencies and (ice_python_wheel is not defined)"
 
 - name: zeroc ice | pip install packages
   become: yes
   pip:
     name: "{{ ice_pip_packages }}"
     state: present
-  when: "ice_pip_packages"
+  when: "ice_pip_packages and (ice_python_wheel is not defined)"
+
+- name: zeroc ice | install python-pip for wheel
+  become: yes
+  yum:
+    name: python-pip
+    state: present
+  when: "ice_python_wheel is defined"
+
+- name: zeroc ice | install ice wheel package
+  become: yes
+  pip:
+    name: "{{ ice_python_wheel }}"
+    state: present
+  when: "ice_python_wheel is defined"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,1 @@
+- src: openmicroscopy.basedeps

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-ice

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,23 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_ice_version(Command, TestinfraBackend):
+    host = TestinfraBackend.get_hostname()
+    assert Command.exists('icegridnode')
+    c = Command('icegridnode --version')
+    if host == 'ice-35':
+        assert c.stderr.startswith('3.5.')
+    else:
+        assert c.stderr.startswith('3.6.')
+
+
+def test_icepy_version(Command, TestinfraBackend):
+    host = TestinfraBackend.get_hostname()
+    c = Command('python -c "import Ice; print Ice.stringVersion()"')
+    if host == 'ice-35':
+        assert c.stdout.startswith('3.5.')
+    else:
+        assert c.stdout.startswith('3.6.')

--- a/vars/ice-3.5.yml
+++ b/vars/ice-3.5.yml
@@ -1,8 +1,7 @@
 ---
 # vars file for roles/ice
 
-# TODO: I can't get https to work :-(
-ice_repourl: http://zeroc.com/download/Ice/3.5/el7/zeroc-ice-el7.repo
+ice_repourl: https://zeroc.com/download/Ice/3.5/el7/zeroc-ice-el7.repo
 ice_runtime_packages:
   - ice
   - ice-python

--- a/vars/ice-3.6.yml
+++ b/vars/ice-3.6.yml
@@ -1,8 +1,7 @@
 ---
 # vars file for roles/ice
 
-# TODO: I can't get https to work :-(
-ice_repourl: http://zeroc.com/download/rpm/el7/zeroc-ice-el7.repo
+ice_repourl: https://zeroc.com/download/rpm/el7/zeroc-ice-el7.repo
 ice_runtime_packages:
   - ice-all-runtime
 ice_devel_packages:


### PR DESCRIPTION
- Removes the default for `ice_version` (previously `3.5`). It is now mandatory to specify `ice_version` in a playbook or role which depends on this one. This ensures the version of ice is consciously selected by the author of a playbook or the author of a role. For example the new `omero-server` and `omero-web` roles currently default to `3.6`.
- Adds a molecule test
- Optional `ice_python_wheel` parameter which can be used to speed up testing of roles which require this one by avoiding the compilation step. This should only be used locally during development to speed up testing when using Ice 3.6. E.g. `ice_python_wheel: http://users.openmicroscopy.org.uk/~spli/centos-zeroc-ice-py/dist/zeroc_ice-3.6.3-cp27-cp27mu-linux_x86_64.whl`
- Ansible 2.2 only

This is a breaking change due to the removal of the default for `ice_version`, and support for Ansible 2.2 only.
