### PR TITLE
Add param to disable installation of ice-devel packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Required:
 - `ice_version`: The Ice version, either 3.5 or 3.6
 
 Optional (expert users only):
+- `ice_install_devel`: Install Ice development packages, default `True`
 - `ice_python_wheel`: URL to a python wheel package to be installed.
   You can use this to provide a precompiled ice-py package for 3.6 as an alternative to automatically compiling from the source package.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for ice
+
+ice_install_devel: True
+ice_python_wheel: ''

--- a/molecule.yml
+++ b/molecule.yml
@@ -34,6 +34,7 @@ ansible:
   host_vars:
     ice-35:
       ice_version: "3.5"
+      ice_install_devel: False
     ice-36:
       ice_version: "3.6"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ ice_devel_packages }}"
+  when: 'ice_install_devel | default(True)'
 
 - name: zeroc ice | install ice pip dependencies
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ ice_devel_packages }}"
-  when: 'ice_install_devel | default(True)'
+  when: ice_install_devel
 
 - name: zeroc ice | install ice pip dependencies
   become: yes
@@ -31,25 +31,25 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ ice_pip_dependencies }}"
-  when: "ice_pip_dependencies and (ice_python_wheel is not defined)"
+  when: "ice_pip_dependencies and (ice_python_wheel | length < 1)"
 
 - name: zeroc ice | pip install packages
   become: yes
   pip:
     name: "{{ ice_pip_packages }}"
     state: present
-  when: "ice_pip_packages and (ice_python_wheel is not defined)"
+  when: "ice_pip_packages and (ice_python_wheel | length < 1)"
 
 - name: zeroc ice | install python-pip for wheel
   become: yes
   yum:
     name: python-pip
     state: present
-  when: "ice_python_wheel is defined"
+  when: "ice_python_wheel | length >= 1"
 
 - name: zeroc ice | install ice wheel package
   become: yes
   pip:
     name: "{{ ice_python_wheel }}"
     state: present
-  when: "ice_python_wheel is defined"
+  when: "ice_python_wheel | length >= 1"

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -21,3 +21,11 @@ def test_icepy_version(Command, TestinfraBackend):
         assert c.stdout.startswith('3.5.')
     else:
         assert c.stdout.startswith('3.6.')
+
+
+def test_ice_devel(Package, TestinfraBackend):
+    host = TestinfraBackend.get_hostname()
+    if host == 'ice-35':
+        assert not Package('ice-c++-devel').is_installed
+    else:
+        assert Package('ice-all-devel').is_installed


### PR DESCRIPTION
The Ice devel packages appear to be unnecessary for running OMERO.server- omitting it should slightly reduce the size of a Docker image.

Non-breaking change (default is to install the devel packages), tag: `2.0.1` or `2.1.0`