### PR TITLE
Update ice-3.6.yml

### DIFF
--- a/vars/ice-3.6.yml
+++ b/vars/ice-3.6.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for roles/ice
 
-ice_repourl: https://zeroc.com/download/rpm/el7/zeroc-ice-el7.repo
+ice_repourl: https://zeroc.com/download/Ice/3.6/el7/zeroc-ice3.6.repo
 ice_runtime_packages:
   - ice-all-runtime
 ice_devel_packages:


### PR DESCRIPTION
Potentially zeroc have broken this upstream. The URL they are now listing for RHEL (Ice 3.6) is not what is in the vars. I don't know much about RPM packaging, some I'm not sure what other implications there could be.

Resolves #4

I haven't looked into Ice 3.5