### PR TITLE
Use individual packages rather than ice-all-runtime meta-package

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
 
 dependencies:
   - role: ome.basedeps
+  - role: ome.java
   # For systems with no upstream binaries most of the work is done here
   - role: ome.deploy_archive
     vars:

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -1,3 +1,4 @@
 ---
 - src: ome.basedeps
+- src: ome.java
 - src: ome.deploy_archive

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -18,7 +18,6 @@
       - libfreeze3.6-c++
       - libice3.6-c++
       - libicestorm3.6
-      - php-ice
     state: present
 
 - name: zeroc ice | install devel packages

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,7 +10,15 @@
 - name: zeroc ice | install runtime packages
   become: true
   yum:
-    name: ice-all-runtime
+    name:
+      - glacier2
+      - icebox
+      - icegrid
+      - icepatch2
+      - libfreeze3.6-c++
+      - libice3.6-c++
+      - libicestorm3.6
+      - php-ice
     state: present
 
 - name: zeroc ice | install devel packages


### PR DESCRIPTION
See https://github.com/ome/omero-server-docker/issues/45

As noted on this issue, the `ice-all-runtime` meta-package depends on `ice-utils-java` and pulls JDK8 on CentOS. This has the undesired effect of competing with the Java version that is managed by the [ome.java](https://galaxy.ansible.com/ome/java) role.

This PR proposes to installs the dependency packages coming from `ice-all-runtime` and adds `ome.java` as a dependency to ensure Java is installed. An additional variable could be added to make the Java dependency conditional if necessary.

Proposed: `4.1.0` or `4.0.1`