### PR TITLE
Bump Ice 3.6.5 binary to latest 20231130 tag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,6 @@ ice_zeroc_ice_ubuntu2204_version: '20221004'
 ice_zeroc_ice_ubuntu2204_sha256: >-
   05e5148f7df0dfc6f06ee2e4445419f95d5b19e4fc8c99660d93af13fb14e709
 
-ice_zeroc_ice_rockylinux9_version: '20230928'
+ice_zeroc_ice_rockylinux9_version: '20231130'
 ice_zeroc_ice_rockylinux9_sha256: >-
-  ff1d0bb418ed4ad0b9637e15086d847b686944d874c326457f98a560ec10d7ed
+  9da10544e46dc95197e670dda4df18200d80991c404b2a2692d635ab59896c5d


### PR DESCRIPTION
As discussed earlier, this consumes the latest Ice binary