### PR TITLE
Become root

### DIFF
--- a/tasks/redhat9.yml
+++ b/tasks/redhat9.yml
@@ -23,6 +23,7 @@
   when: rockyrepo_name.stat.exists
 
 - name: zeroc ice | Enable crp repo in rocky
+  become: true
   ansible.builtin.replace:
     path:  /etc/yum.repos.d/rocky.repo
     # create: false


### PR DESCRIPTION
When running the playbook to create a rocky9 pilot, I got:
```
TASK [ome.ice : zeroc ice | Enable crp repo in rocky] ******************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: PermissionError: [Errno 13] Permission denied: b'/home/rocky/.ansible/tmp/ansible-tmp-1709729310.131924-28076-254820919668783/tmpqgzrgzlf' -> b'/etc/yum.repos.d/rocky.repo'
fatal: [2f5d1f82-2aad-433b-ab9f-98c5fe25ffa5]: FAILED! => {"changed": false, "msg": "The destination directory (/etc/yum.repos.d) is not writable by the current user. Error was: [Errno 13] Permission denied: b'/etc/yum.repos.d/.ansible_tmpestecxeprocky.repo'"}
```

This PR fixes the issue.